### PR TITLE
Fix HTML typo and string helper

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -3,6 +3,7 @@ package router
 import (
 	"html/template"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/mgrinsted/pylos/internal/handlers"
@@ -48,7 +49,7 @@ func loadTemplates() *template.Template {
 			return s[start:end]
 		},
 		"upper": func(s string) string {
-			return string([]rune(s)[0] - 32)
+			return strings.ToUpper(s)
 		},
 		"default": func(defaultValue, value interface{}) interface{} {
 			if value == nil || value == "" {

--- a/templates/partials/pagination.html
+++ b/templates/partials/pagination.html
@@ -1,6 +1,6 @@
 {{ define "partials/pagination" }}
 {{ if gt .Pagination.TotalPages 1 }}
-<diiv class="flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
+<div class="flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
   <div class="-mt-px flex w-0 flex-1">
     {{ if gt .Pagination.Page 1 }}
     <a href="/customers?page={{ sub .Pagination.Page 1 }}&limit={{ .Pagination.PageSize }}"


### PR DESCRIPTION
## Summary
- fix `diiv` typo in pagination partial template
- improve `upper` helper function to avoid panics and uppercase whole string

## Testing
- `go test ./...` *(fails: downloading modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6862c08318108321a5ec6e02d557426d