### PR TITLE
Fix pagination template context

### DIFF
--- a/templates/partials/pagination.html
+++ b/templates/partials/pagination.html
@@ -15,11 +15,12 @@
   <div class="hidden md:-mt-px md:flex">
     {{ $page := .Pagination.Page }}
     {{ $total := .Pagination.TotalPages }}
+    {{ $root := . }}
     {{ range $i, $ := iter $total }}
       {{ $pageNum := add $i 1 }}
       {{ if or (eq $pageNum 1) (eq $pageNum $total) (and (ge $pageNum (sub $page 2)) (le $pageNum (add $page 2))) }}
-        <a href="/customers?page={{ $pageNum }}&limit={{ .Pagination.PageSize }}"
-           hx-get="/customers?page={{ $pageNum }}&limit={{ .Pagination.PageSize }}"
+        <a href="/customers?page={{ $pageNum }}&limit={{ $root.Pagination.PageSize }}"
+           hx-get="/customers?page={{ $pageNum }}&limit={{ $root.Pagination.PageSize }}"
            hx-target="#customer-table-container" hx-swap="innerHTML"
            class="inline-flex items-center border-t-2 px-4 pt-4 text-sm font-medium {{ if eq $page $pageNum }}border-indigo-500 text-indigo-600{{ else }}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{ end }}">
           {{ $pageNum }}


### PR DESCRIPTION
## Summary
- fix pagination.html to preserve root context during range loop

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862c2ca8268832184c231abd5e48d41