### PR TITLE
Fix pagination HTMX partial rendering

### DIFF
--- a/internal/handlers/customers_handler.go
+++ b/internal/handlers/customers_handler.go
@@ -72,10 +72,15 @@ func (h *EstateCustomerHandler) CustomersPageHandler(templates *template.Templat
 		// Determine which template to execute
 		var templateName string
 		if r.Header.Get("HX-Request") == "true" {
-			// For HTMX requests, return just the content
-			templateName = "content"
+			switch r.Header.Get("HX-Target") {
+			case "customer-table-container":
+				templateName = "partials/table_container"
+			default:
+				// For HTMX requests targeting other elements, return the full content
+				templateName = "content"
+			}
 		} else {
-			// For full page requests, return the full customers page
+			// For full page requests, return the complete page
 			templateName = "customers"
 		}
 

--- a/templates/customers.html
+++ b/templates/customers.html
@@ -15,10 +15,7 @@
     </div>
 </div>
 
-<div class="mt-8" id="customer-table-container">
-    {{ template "partials/table" . }}
-    {{ template "partials/pagination" . }}
-</div>
+{{ template "partials/table_container" . }}
 
 <!-- Page size selector -->
 <div class="flex justify-end items-center mt-4">

--- a/templates/partials/table_container.html
+++ b/templates/partials/table_container.html
@@ -1,0 +1,6 @@
+{{ define "partials/table_container" }}
+<div class="mt-8" id="customer-table-container">
+    {{ template "partials/table" . }}
+    {{ template "partials/pagination" . }}
+</div>
+{{ end }}


### PR DESCRIPTION
## Summary
- avoid duplicating markup by splitting table container into a partial
- return just the table container fragment for HTMX requests

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6862c43e78c8832189b89656e287b732